### PR TITLE
Added async processing for mediators

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ When receiving a request, the engine will send your actor a `MediatorHTTPRequest
 * **ExceptError** - An exception has occurred and the request should end with a `500 Internal Server Error` response.
 * **AddOrchestrationToCoreResponse** - Add orchestration details to the request response. This message can be sent as many times as required.
 * **PutPropertyInCoreResponse** - Put a name/value pair property in the request response. This message can be sent as many times as required.
+* **AcceptedAsyncRequest** - Indicates to the request handler that the request will be processed asyncronously. When this message is sent, the request handler will immediately respond to the client with a 202 (Accepted) status, and processing can continue. The request can still be finalized by sending a FinishRequest message. When this is done, the engine will send an update with the response details to the HIM core.
 
 # Connectors
 The mediator engine provides several connectors that you can use in order to connect to other services. These are running as actors on the root context, so can be looked up as an `ActorSelection`:

--- a/src/main/java/org/openhim/mediator/engine/MediatorRequestActor.java
+++ b/src/main/java/org/openhim/mediator/engine/MediatorRequestActor.java
@@ -37,14 +37,14 @@ public class MediatorRequestActor extends UntypedActor {
 
     LoggingAdapter log = Logging.getLogger(getContext().system(), this);
 
-    private ActorRef requestCaller;
-    private CoreResponse response = new CoreResponse();
-    private String coreTransactionID;
-    private boolean async = false;
+    protected ActorRef requestCaller;
+    protected CoreResponse response = new CoreResponse();
+    protected String coreTransactionID;
+    protected boolean async = false;
     //finalizingRequest becomes true as soon as we "respondAndEnd()"
-    private boolean finalizingRequest = false;
+    protected boolean finalizingRequest = false;
 
-    private final MediatorConfig config;
+    protected final MediatorConfig config;
 
 
     public MediatorRequestActor(MediatorConfig config) {

--- a/src/main/java/org/openhim/mediator/engine/MediatorRootActor.java
+++ b/src/main/java/org/openhim/mediator/engine/MediatorRootActor.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Callable;
  * <br/><br/>
  * Its roles are to:
  * <ul>
- * <li>launch/kill new request actors,</li>
+ * <li>launch new request actors,</li>
  * <li>contain the request context,</li>
  * <li>launch all single instance actors on startup, and</li>
  * <li>trigger the registration of the mediator to core.</li>
@@ -77,7 +77,6 @@ public class MediatorRootActor extends UntypedActor {
         f.onComplete(new OnComplete<Boolean>() {
             @Override
             public void onComplete(Throwable throwable, Boolean result) throws Throwable {
-                requestActor.tell(PoisonPill.getInstance(), getSelf());
                 if (throwable!=null) {
                     log.error(throwable, "Request containment exception");
                 }

--- a/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
+++ b/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
@@ -12,10 +12,7 @@ import akka.event.Logging;
 import akka.event.LoggingAdapter;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.*;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.conn.ssl.*;
 import org.apache.http.entity.StringEntity;
@@ -95,6 +92,11 @@ public class HTTPConnector extends UntypedActor {
                 uriReq = new HttpPost(buildURI(req));
                 StringEntity entity = new StringEntity(req.getBody());
                 ((HttpPost) uriReq).setEntity(entity);
+                break;
+            case "PUT":
+                uriReq = new HttpPut(buildURI(req));
+                StringEntity putEntity = new StringEntity(req.getBody());
+                ((HttpPut) uriReq).setEntity(putEntity);
                 break;
             default:
                 throw new UnsupportedOperationException(req.getMethod() + " requests not supported");

--- a/src/main/java/org/openhim/mediator/engine/messages/AcceptedAsyncRequest.java
+++ b/src/main/java/org/openhim/mediator/engine/messages/AcceptedAsyncRequest.java
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.openhim.mediator.engine.messages;
+
+/**
+ * Indicates that the mediator has accepted the request asyncronously.
+ * The mediator http server should therefore respond to the client with an http status of 202,
+ * and the final response will be updated to core at a later stage.
+ */
+public class AcceptedAsyncRequest {
+}

--- a/src/test/java/org/openhim/mediator/engine/MediatorRequestActorTest.java
+++ b/src/test/java/org/openhim/mediator/engine/MediatorRequestActorTest.java
@@ -1,0 +1,302 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.openhim.mediator.engine;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.actor.UntypedActor;
+import akka.testkit.JavaTestKit;
+import akka.testkit.TestActorRef;
+import fi.iki.elonen.NanoHTTPD;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpStatus;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openhim.mediator.engine.messages.*;
+import org.openhim.mediator.engine.testing.MockHTTPConnector;
+import org.openhim.mediator.engine.testing.MockLauncher;
+import scala.concurrent.duration.Duration;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class MediatorRequestActorTest {
+    /**
+     * Mocks a mediator route receiver like someone using the engine will implement in order to receive requests.
+     */
+    private abstract static class MockRouteActor extends UntypedActor {
+        public abstract void executeOnReceive(MediatorHTTPRequest msg);
+
+        @Override
+        public void onReceive(Object msg) throws Exception {
+            if (msg instanceof MediatorHTTPRequest) {
+                executeOnReceive((MediatorHTTPRequest) msg);
+            } else {
+                fail("MediatorRequestActor should never send any messages to a route other than MediatorHTTPRequest");
+            }
+        }
+    }
+
+    static ActorSystem system;
+    MediatorConfig testConfig;
+
+    @BeforeClass
+    public static void setup() {
+        system = ActorSystem.create();
+    }
+
+    @AfterClass
+    public static void teardown() {
+        JavaTestKit.shutdownActorSystem(system);
+        system = null;
+    }
+
+    @Before
+    public void before() throws IOException {
+        testConfig = new MediatorConfig();
+        testConfig.setName("request-actor-tests");
+
+        InputStream regInfo = getClass().getClassLoader().getResourceAsStream("test-registration-info.json");
+        testConfig.setRegistrationConfig(new RegistrationConfig(regInfo));
+    }
+
+    private static class BasicRoutingMock extends MockRouteActor {
+        @Override
+        public void executeOnReceive(MediatorHTTPRequest msg) {
+            assertEquals("http", msg.getScheme());
+            assertEquals("GET", msg.getMethod());
+            assertEquals("/test", msg.getPath());
+
+            FinishRequest fr = new FinishRequest("basic-routing", "text/plain", HttpStatus.SC_OK);
+            msg.getRequestHandler().tell(fr, getSelf());
+        }
+    }
+
+    @Test
+    public void testMessage_BasicRouting() throws Exception {
+        new JavaTestKit(system) {{
+            RoutingTable table = new RoutingTable();
+            table.addRoute("/test", BasicRoutingMock.class);
+            testConfig.setRoutingTable(table);
+
+            TestActorRef<MediatorRequestActor> actor = TestActorRef.create(system, Props.create(MediatorRequestActor.class, testConfig));
+            NanoHTTPD.IHTTPSession testSession = buildMockIHTTPSession(actor, "/test", NanoHTTPD.Method.GET, Collections.<String, String>emptyMap());
+            actor.tell(testSession, getRef());
+
+            NanoHTTPD.Response response = expectMsgClass(Duration.create(1, TimeUnit.SECONDS), NanoHTTPD.Response.class);
+
+            String body = IOUtils.toString(response.getData());
+            assertTrue(body.contains("\"body\":\"basic-routing\""));
+            assertTrue(body.contains("\"status\":200"));
+        }};
+    }
+
+    private static class AsyncRoutingMock extends MockRouteActor {
+        @Override
+        public void executeOnReceive(MediatorHTTPRequest msg) {
+            //accepted async
+            msg.getRequestHandler().tell(new AcceptedAsyncRequest(), getSelf());
+
+            //end request
+            FinishRequest fr = new FinishRequest("async-routing", "text/plain", HttpStatus.SC_OK);
+            msg.getRequestHandler().tell(fr, getSelf());
+        }
+    }
+
+    private static class MockCoreAPI extends MockHTTPConnector {
+        @Override
+        public String getResponse() {
+            return "Updated";
+        }
+
+        @Override
+        public Integer getStatus() {
+            return 200;
+        }
+
+        @Override
+        public Map<String, String> getHeaders() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public void executeOnReceive(MediatorHTTPRequest req) {
+            assertEquals("/transactions/test-async", req.getPath());
+            assertEquals("PUT", req.getMethod());
+        }
+    }
+
+    @Test
+    public void testMessage_AsyncRouting() throws Exception {
+        new JavaTestKit(system) {{
+            //mock core api
+            MockLauncher.ActorToLaunch mockCoreAPI = new MockLauncher.ActorToLaunch("core-api-connector", MockCoreAPI.class);
+            MockLauncher.launchActors(system, testConfig.getName(), Collections.singletonList(mockCoreAPI));
+
+            //route to mock receiver
+            RoutingTable table = new RoutingTable();
+            table.addRoute("/test", AsyncRoutingMock.class);
+            testConfig.setRoutingTable(table);
+
+            //route request
+            TestActorRef<MediatorRequestActor> actor = TestActorRef.create(system, Props.create(MediatorRequestActor.class, testConfig));
+            assertFalse(actor.underlyingActor().async);
+
+            NanoHTTPD.IHTTPSession testSession = buildMockIHTTPSession(actor, "/test", NanoHTTPD.Method.GET, Collections.singletonMap("X-OpenHIM-TransactionID", "test-async"));
+            actor.tell(testSession, getRef());
+
+            //get response
+            NanoHTTPD.Response response = expectMsgClass(Duration.create(1, TimeUnit.SECONDS), NanoHTTPD.Response.class);
+
+            assertTrue("Async should be enabled", actor.underlyingActor().async);
+            assertEquals("Core transaction ID should be set", "test-async", actor.underlyingActor().coreTransactionID);
+
+            //request handler should respond with 202 Accepted
+            String body = IOUtils.toString(response.getData());
+            assertTrue(body.contains("\"status\":202"));
+
+            //but update response token with final result
+            assertNotNull(actor.underlyingActor().response);
+            assertNotNull(actor.underlyingActor().response.getResponse());
+            assertEquals(new Integer(200), actor.underlyingActor().response.getResponse().getStatus());
+            assertEquals("async-routing", actor.underlyingActor().response.getResponse().getBody());
+
+            MockLauncher.clearActors(system, testConfig.getName());
+        }};
+    }
+
+    private static class ErrorRoutingMock extends MockRouteActor {
+        public static class TestException extends Exception {
+            public TestException() {
+                super("test-exception (this is expected)");
+            }
+        }
+
+        @Override
+        public void executeOnReceive(MediatorHTTPRequest msg) {
+            try {
+                throw new TestException();
+            } catch (TestException ex) {
+                msg.getRequestHandler().tell(new ExceptError(ex), getSelf());
+            }
+        }
+    }
+
+    @Test
+    public void testMessage_ExceptError() throws Exception {
+        new JavaTestKit(system) {{
+            RoutingTable table = new RoutingTable();
+            table.addRoute("/test", ErrorRoutingMock.class);
+            testConfig.setRoutingTable(table);
+
+            TestActorRef<MediatorRequestActor> actor = TestActorRef.create(system, Props.create(MediatorRequestActor.class, testConfig));
+            NanoHTTPD.IHTTPSession testSession = buildMockIHTTPSession(actor, "/test", NanoHTTPD.Method.GET, Collections.<String, String>emptyMap());
+            actor.tell(testSession, getRef());
+
+            NanoHTTPD.Response response = expectMsgClass(Duration.create(1, TimeUnit.SECONDS), NanoHTTPD.Response.class);
+
+            String body = IOUtils.toString(response.getData());
+            assertTrue("The exception message should be returned in the body", body.contains("\"body\":\"test-exception (this is expected)\""));
+            assertTrue("Expect status 500 Internal Server Error", body.contains("\"status\":500"));
+        }};
+    }
+
+    @Test
+    public void testMessage_AddOrchestrationToCoreResponse() throws Exception {
+        new JavaTestKit(system) {{
+            TestActorRef<MediatorRequestActor> actor = TestActorRef.create(system, Props.create(MediatorRequestActor.class, testConfig));
+
+            CoreResponse.Orchestration testOrch = new CoreResponse.Orchestration();
+            testOrch.setName("unit-test");
+
+            actor.tell(new AddOrchestrationToCoreResponse(testOrch), getRef());
+            expectNoMsg(Duration.create(500, TimeUnit.MILLISECONDS));
+
+            assertNotNull(actor.underlyingActor().response);
+            assertNotNull(actor.underlyingActor().response.getOrchestrations());
+            assertEquals("unit-test", actor.underlyingActor().response.getOrchestrations().get(0).getName());
+        }};
+    }
+
+    @Test
+    public void testMessage_PutPropertyInCoreResponse() throws Exception {
+        new JavaTestKit(system) {{
+            TestActorRef<MediatorRequestActor> actor = TestActorRef.create(system, Props.create(MediatorRequestActor.class, testConfig));
+
+            actor.tell(new PutPropertyInCoreResponse("test-property", "test-value"), getRef());
+            expectNoMsg(Duration.create(500, TimeUnit.MILLISECONDS));
+
+            assertNotNull(actor.underlyingActor().response);
+            assertNotNull(actor.underlyingActor().response.getProperties());
+            assertEquals("test-value", actor.underlyingActor().response.getProperties().get("test-property"));
+        }};
+    }
+
+
+    /**
+     * Mocks a received HTTP request
+     */
+    private NanoHTTPD.IHTTPSession buildMockIHTTPSession(final ActorRef requestHandler, final String path, final NanoHTTPD.Method method, final Map<String, String> headers) {
+        return new NanoHTTPD.IHTTPSession() {
+            @Override
+            public void execute() throws IOException {}
+
+            @Override
+            public Map<String, String> getParms() {
+                return null;
+            }
+
+            @Override
+            public Map<String, String> getHeaders() {
+                return headers;
+            }
+
+            @Override
+            public String getUri() {
+                return path;
+            }
+
+            @Override
+            public String getQueryParameterString() {
+                return null;
+            }
+
+            @Override
+            public NanoHTTPD.Method getMethod() {
+                return method;
+            }
+
+            @Override
+            public InputStream getInputStream() {
+                return null;
+            }
+
+            @Override
+            public NanoHTTPD.CookieHandler getCookies() {
+                return null;
+            }
+
+            @Override
+            public void parseBody(Map<String, String> files) throws IOException, NanoHTTPD.ResponseException {
+
+            }
+
+            @Override
+            public ActorRef getRequestActor() {
+                return requestHandler;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #1 

@rcrichton would you be keen to review this?

I know it might be a bit hectic to jump into, but it would definitely be great to get some extra eyes on this; and it would be good to validate the flow logic. So basically the `MediatorRequestActor` is the handler for a request, its job is to do all those "behind-the-scenes-magic" tasks that we don't want mediator implementations don't need to worry about, like handling the json+openhim response and providing mediators with an interface for dealing with the client interface or handling errors.

I've changed it now to accept a message that'll tell it that the request should be processed async. In nutshell, a mediator could now do something like
```
    @Override
    public void onReceive(Object msg) throws Exception {
        if (msg instanceof MediatorHTTPRequest) {
            msg.getRequestHandler().tell(new AcceptedAsyncRequest(), getSelf()); //respond to client 202

    //do lots of hectic processing
    //and sometime later
    FinishRequest response = new FinishRequest(finalResult, "text/xml", HttpStatus.SC_OK);
    msg.getRequestHandler().tell(response, getSelf()); //update core api
```