### PR TITLE
Switched to using either iso or millis for dates received in orchestr…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>org.openhim</groupId>
 <artifactId>mediator-engine</artifactId>
-<version>1.1.0-SNAPSHOT</version>
+<version>2.0.0-SNAPSHOT</version>
 <packaging>jar</packaging>
 <name>OpenHIM Mediator Engine</name>
 <description>An engine for building OpenHIM mediators based on the Akka framework</description>
@@ -72,6 +72,11 @@
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-http-server</artifactId>
     <version>2.3.18</version>
+  </dependency>
+    <dependency>
+    <groupId>joda-time</groupId>
+    <artifactId>joda-time</artifactId>
+    <version>2.8.1</version>
   </dependency>
   <!-- Testing dependencies -->
   <dependency>

--- a/src/main/java/org/openhim/mediator/engine/CoreResponse.java
+++ b/src/main/java/org/openhim/mediator/engine/CoreResponse.java
@@ -12,9 +12,6 @@ import org.joda.time.format.ISODateTimeFormat;
 
 import java.io.Serializable;
 import java.lang.reflect.Type;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;

--- a/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
+++ b/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
@@ -239,14 +239,14 @@ public class HTTPConnector extends UntypedActor {
                         if (throwable != null) {
                             throw throwable;
                         }
-
-                        //send response
                         MediatorHTTPResponse response = buildResponse(req, result);
-                        req.getRespondTo().tell(response, getSelf());
 
                         //enrich engine response
                         CoreResponse.Orchestration orch = buildHTTPOrchestration(req, response);
                         req.getRequestHandler().tell(new AddOrchestrationToCoreResponse(orch), getSelf());
+
+                        //send response
+                        req.getRespondTo().tell(response, getSelf());
                     } catch (Exception ex) {
                         req.getRequestHandler().tell(new ExceptError(ex), getSelf());
                     } finally {

--- a/src/test/java/org/openhim/mediator/engine/CoreResponseTest.java
+++ b/src/test/java/org/openhim/mediator/engine/CoreResponseTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 
 import static org.junit.Assert.*;
 
@@ -19,6 +20,7 @@ public class CoreResponseTest {
     @Test
     public void testParse() throws Exception {
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        format.setTimeZone(TimeZone.getTimeZone("GMT+2"));
         InputStream in = CoreResponseTest.class.getClassLoader().getResourceAsStream("core-response.json");
         String json = IOUtils.toString(in);
 
@@ -64,6 +66,7 @@ public class CoreResponseTest {
     @Test
     public void testDateformats() throws Exception {
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        format.setTimeZone(TimeZone.getTimeZone("GMT+2"));
         InputStream in = CoreResponseTest.class.getClassLoader().getResourceAsStream("core-response-multiple-dates.json");
         String json = IOUtils.toString(in);
 

--- a/src/test/java/org/openhim/mediator/engine/CoreResponseTest.java
+++ b/src/test/java/org/openhim/mediator/engine/CoreResponseTest.java
@@ -62,6 +62,18 @@ public class CoreResponseTest {
     }
 
     @Test
+    public void testDateformats() throws Exception {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        InputStream in = CoreResponseTest.class.getClassLoader().getResourceAsStream("core-response-multiple-dates.json");
+        String json = IOUtils.toString(in);
+
+        CoreResponse response = CoreResponse.parse(json);
+        assertEquals("Should parse ISO8601 in UTC", "2015-01-15 14:51", format.format(response.getResponse().getTimestamp()));
+        assertEquals("Should parse ISO8601 in GMT+2", "2015-01-15 14:51", format.format(response.getOrchestrations().get(0).getRequest().getTimestamp()));
+        assertEquals("Should parse timestamp in milliseconds", "2015-01-15 14:51", format.format(response.getOrchestrations().get(0).getResponse().getTimestamp()));
+    }
+
+    @Test
     public void testParse_BadContent() throws Exception {
         String json = "bad content!";
 

--- a/src/test/resources/core-response-multiple-dates.json
+++ b/src/test/resources/core-response-multiple-dates.json
@@ -5,7 +5,7 @@
         "status": 200,
         "headers": { "Content-Type": "text/plain" },
         "body": "a test response",
-        "timestamp": "2015-01-15T14:51:55.000+02:00"
+        "timestamp": "2015-01-15T12:51:55.000+00:00"
     },
     "orchestrations": [
         {
@@ -22,7 +22,7 @@
                 "status": 201,
                 "headers": { "Content-Type": "text/plain" },
                 "body": "created",
-                "timestamp": "2015-01-15T14:51:55.000+02:00"
+                "timestamp": 1421326260000
             }
         },
         {
@@ -30,7 +30,7 @@
             "request": {
                 "path": "/orch2",
                 "method": "GET",
-                "timestamp": "2015-01-15T14:51:55.000+02:00"
+                "timestamp": "2015-01-15T12:51:55.000+00:00"
             },
             "response": {
                 "status": 200,


### PR DESCRIPTION
…ations.

@rcrichton you wouldn't mind taking a look at this for me?

This addresses the parsing of timestamps when a mediator receives json+openhim responses from other mediators (i.e. chained mediators). Before we were just using the gson's default strategy, but I switched it now in order to use ISO or timestamps in milliseconds.

This change means we need to bump up the major version number since the old strategy isn't supported anymore, but I think this is good. What do you think?