### PR TITLE
http-connector: Added support for URI strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>org.openhim</groupId>
 <artifactId>mediator-engine</artifactId>
-<version>2.1.0</version>
+<version>2.2.0</version>
 <packaging>jar</packaging>
 <name>OpenHIM Mediator Engine</name>
 <description>An engine for building OpenHIM mediators based on the Akka framework</description>

--- a/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
+++ b/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
@@ -66,11 +66,18 @@ public class HTTPConnector extends UntypedActor {
     }
 
     private URI buildURI(MediatorHTTPRequest req) throws URISyntaxException {
-        URIBuilder builder = new URIBuilder()
-                .setScheme(req.getScheme())
-                .setHost(req.getHost())
-                .setPort(req.getPort())
-                .setPath(req.getPath());
+        URIBuilder builder;
+
+        if (req.getUri()!=null) {
+            builder = new URIBuilder(req.getUri());
+        } else {
+            builder = new URIBuilder()
+                    .setScheme(req.getScheme())
+                    .setHost(req.getHost())
+                    .setPort(req.getPort())
+                    .setPath(req.getPath());
+        }
+
         if (req.getParams()!=null) {
             Iterator<String> iter = req.getParams().keySet().iterator();
             while (iter.hasNext()) {
@@ -193,10 +200,12 @@ public class HTTPConnector extends UntypedActor {
         orch.setName(req.getOrchestration());
 
         CoreResponse.Request orchReq = new CoreResponse.Request();
-        orchReq.setBody(req.getBody());
-        orchReq.setHost(req.getHost());
-        orchReq.setPort(Integer.toString(req.getPort()));
-        orchReq.setPath(req.getPath());
+        if (req.getUri()==null) {
+            orchReq.setBody(req.getBody());
+            orchReq.setHost(req.getHost());
+            orchReq.setPort(Integer.toString(req.getPort()));
+            orchReq.setPath(req.getPath());
+        }
         orchReq.setMethod(req.getMethod());
         orchReq.setHeaders(req.getHeaders());
         orch.setRequest(orchReq);

--- a/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
+++ b/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
@@ -201,11 +201,11 @@ public class HTTPConnector extends UntypedActor {
 
         CoreResponse.Request orchReq = new CoreResponse.Request();
         if (req.getUri()==null) {
-            orchReq.setBody(req.getBody());
             orchReq.setHost(req.getHost());
             orchReq.setPort(Integer.toString(req.getPort()));
             orchReq.setPath(req.getPath());
         }
+        orchReq.setBody(req.getBody());
         orchReq.setMethod(req.getMethod());
         orchReq.setHeaders(req.getHeaders());
         orch.setRequest(orchReq);

--- a/src/main/java/org/openhim/mediator/engine/messages/MediatorHTTPRequest.java
+++ b/src/main/java/org/openhim/mediator/engine/messages/MediatorHTTPRequest.java
@@ -15,6 +15,7 @@ import java.util.TreeMap;
 
 public class MediatorHTTPRequest extends MediatorRequestMessage {
     private final String method;
+    private final String uri;
     private final String scheme;
     private final String host;
     private final Integer port;
@@ -23,11 +24,12 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
     private final Map<String, String> headers;
     private final Map<String, String> params;
 
-    public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
-                               String method, String scheme, String host, Integer port, String path, String body,
+    private MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
+                               String method, String uri, String scheme, String host, Integer port, String path, String body,
                                Map<String, String> headers, Map<String, String> params, String correlationId) {
         super(requestHandler, respondTo, orchestration, correlationId);
         this.method = method;
+        this.uri = uri;
         this.scheme = scheme;
         this.host = host;
         this.port = port;
@@ -37,18 +39,65 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
         this.params = params;
     }
 
+    /**
+     * Construct a new mediator http request using a URI (string)
+     */
+    public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
+                               String method, String uri, String body, Map<String, String> headers, Map<String, String> params, String correlationId) {
+        this(
+                requestHandler, respondTo, orchestration, method, uri, null, null, null, null, body, headers, params, correlationId
+        );
+    }
+
+    /**
+     * Construct a new mediator http request using for a particular scheme, host, port and path
+     */
+    public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
+                               String method, String scheme, String host, Integer port, String path, String body,
+                               Map<String, String> headers, Map<String, String> params, String correlationId) {
+        this(
+                requestHandler, respondTo, orchestration, method, null, scheme, host, port, path, body, headers, params, correlationId
+        );
+    }
+
+    /**
+     * Construct a new mediator http request using a URI (string)
+     */
+    public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
+                               String method, String uri, String body, Map<String, String> headers, Map<String, String> params) {
+        this(
+                requestHandler, respondTo, orchestration, method, uri, null, null, null, null, body, headers, params, null
+        );
+    }
+
+    /**
+     * Construct a new mediator http request using for a particular scheme, host, port and path
+     */
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
                                String method, String scheme, String host, Integer port, String path, String body,
                                Map<String, String> headers, Map<String, String> params) {
         this(
-                requestHandler, respondTo, orchestration, method, scheme, host, port, path, body, headers, params, null
+                requestHandler, respondTo, orchestration, method, null, scheme, host, port, path, body, headers, params, null
         );
     }
 
+    /**
+     * Construct a new mediator http request using a URI (string)
+     */
+    public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration, String method, String uri) {
+        this(
+                requestHandler, respondTo, orchestration, method, uri, null, null, null, null,
+                null, Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap(), null
+        );
+    }
+
+    /**
+     * Construct a new mediator http request using for a particular scheme, host, port and path
+     */
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
                                String method, String scheme, String host, Integer port, String path) {
         this(
-                requestHandler, respondTo, orchestration, method, scheme, host, port, path,
+                requestHandler, respondTo, orchestration, method, null, scheme, host, port, path,
                 null, Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap(), null
         );
     }
@@ -62,6 +111,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
                 requestToCopy.getRespondTo(),
                 requestToCopy.getOrchestration(),
                 requestToCopy.getMethod(),
+                requestToCopy.getUri(),
                 requestToCopy.getScheme(),
                 requestToCopy.getHost(),
                 requestToCopy.getPort(),
@@ -82,6 +132,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
                 respondTo,
                 requestToCopy.getOrchestration(),
                 requestToCopy.getMethod(),
+                requestToCopy.getUri(),
                 requestToCopy.getScheme(),
                 requestToCopy.getHost(),
                 requestToCopy.getPort(),
@@ -104,6 +155,10 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
 
     public String getMethod() {
         return method;
+    }
+
+    public String getUri() {
+        return uri;
     }
 
     public String getScheme() {


### PR DESCRIPTION
@rcrichton you wouldn't mind just doing a quick sanity check on this for me? I just added support for URI strings in the http-connector (as opposed to discrete host, port and path)