### PR TITLE
Multi params

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Include the jar in your mediator project. If you're using Maven, simply add the 
 <dependency>
   <groupId>org.openhim</groupId>
   <artifactId>mediator-engine</artifactId>
-  <version>2.3.1</version>
+  <version>3.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>org.openhim</groupId>
 <artifactId>mediator-engine</artifactId>
-<version>2.3.1</version>
+<version>3.0.0-SNAPSHOT</version>
 <packaging>jar</packaging>
 <name>OpenHIM Mediator Engine</name>
 <description>An engine for building OpenHIM mediators based on the Akka framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
     <version>2.4</version>
   </dependency>
   <dependency>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-lang3</artifactId>
+    <version>3.4</version>
+  </dependency>
+  <dependency>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson</artifactId>
     <version>2.3.1</version>

--- a/src/main/java/org/openhim/mediator/engine/MediatorRootActor.java
+++ b/src/main/java/org/openhim/mediator/engine/MediatorRootActor.java
@@ -15,6 +15,7 @@ import akka.dispatch.OnComplete;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.glassfish.grizzly.ReadHandler;
 import org.glassfish.grizzly.http.io.NIOReader;
 import org.glassfish.grizzly.http.server.Response;
@@ -35,7 +36,8 @@ import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
@@ -130,9 +132,11 @@ public class MediatorRootActor extends UntypedActor {
             headers.put(hdr, request.getRequest().getHeader(hdr));
         }
 
-        final Map<String, String[]> params = new HashMap<>();
+        final List<Pair<String, String>> params = new ArrayList<>();
         for (String param : request.getRequest().getParameterNames()) {
-            params.put(param, request.getRequest().getParameterValues(param));
+            for (String value : request.getRequest().getParameterValues(param)) {
+                params.add(Pair.of(param, value));
+            }
         }
 
         in.notifyAvailable(new ReadHandler() {
@@ -180,7 +184,7 @@ public class MediatorRootActor extends UntypedActor {
     }
 
     private MediatorHTTPRequest buildMediatorHTTPRequest(ActorRef requestHandler, GrizzlyHTTPRequest request,
-                                                         String body, Map<String, String> headers, Map<String, String[]> params) {
+                                                         String body, Map<String, String> headers, List<Pair<String, String>> params) {
         return new MediatorHTTPRequest(
                 requestHandler,
                 requestHandler,

--- a/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
+++ b/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
@@ -82,7 +82,9 @@ public class HTTPConnector extends UntypedActor {
             Iterator<String> iter = req.getParams().keySet().iterator();
             while (iter.hasNext()) {
                 String param = iter.next();
-                builder.addParameter(param, req.getParams().get(param));
+                for (String p : req.getParams().get(param)) {
+                    builder.addParameter(param, p);
+                }
             }
         }
         return builder.build();

--- a/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
+++ b/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
@@ -11,6 +11,7 @@ import akka.dispatch.OnComplete;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.Header;
 import org.apache.http.client.methods.*;
 import org.apache.http.client.utils.URIBuilder;
@@ -79,14 +80,11 @@ public class HTTPConnector extends UntypedActor {
         }
 
         if (req.getParams()!=null) {
-            Iterator<String> iter = req.getParams().keySet().iterator();
-            while (iter.hasNext()) {
-                String param = iter.next();
-                for (String p : req.getParams().get(param)) {
-                    builder.addParameter(param, p);
-                }
+            for (Pair<String, String> param : req.getParams()) {
+                builder.addParameter(param.getKey(), param.getValue());
             }
         }
+
         return builder.build();
     }
 

--- a/src/main/java/org/openhim/mediator/engine/messages/MediatorHTTPRequest.java
+++ b/src/main/java/org/openhim/mediator/engine/messages/MediatorHTTPRequest.java
@@ -10,6 +10,7 @@ import akka.actor.ActorRef;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -22,11 +23,11 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
     private final String path;
     private final String body;
     private final Map<String, String> headers;
-    private final Map<String, String> params;
+    private final Map<String, String[]> params;
 
     private MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
                                String method, String uri, String scheme, String host, Integer port, String path, String body,
-                               Map<String, String> headers, Map<String, String> params, String correlationId) {
+                               Map<String, String> headers, Map<String, String[]> params, String correlationId) {
         super(requestHandler, respondTo, orchestration, correlationId);
         this.method = method;
         this.uri = uri;
@@ -43,7 +44,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
      * Construct a new mediator http request using a URI (string)
      */
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
-                               String method, String uri, String body, Map<String, String> headers, Map<String, String> params, String correlationId) {
+                               String method, String uri, String body, Map<String, String> headers, Map<String, String[]> params, String correlationId) {
         this(
                 requestHandler, respondTo, orchestration, method, uri, null, null, null, null, body, headers, params, correlationId
         );
@@ -54,7 +55,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
      */
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
                                String method, String scheme, String host, Integer port, String path, String body,
-                               Map<String, String> headers, Map<String, String> params, String correlationId) {
+                               Map<String, String> headers, Map<String, String[]> params, String correlationId) {
         this(
                 requestHandler, respondTo, orchestration, method, null, scheme, host, port, path, body, headers, params, correlationId
         );
@@ -64,7 +65,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
      * Construct a new mediator http request using a URI (string)
      */
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
-                               String method, String uri, String body, Map<String, String> headers, Map<String, String> params) {
+                               String method, String uri, String body, Map<String, String> headers, Map<String, String[]> params) {
         this(
                 requestHandler, respondTo, orchestration, method, uri, null, null, null, null, body, headers, params, null
         );
@@ -75,7 +76,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
      */
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
                                String method, String scheme, String host, Integer port, String path, String body,
-                               Map<String, String> headers, Map<String, String> params) {
+                               Map<String, String> headers, Map<String, String[]> params) {
         this(
                 requestHandler, respondTo, orchestration, method, null, scheme, host, port, path, body, headers, params, null
         );
@@ -87,7 +88,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration, String method, String uri) {
         this(
                 requestHandler, respondTo, orchestration, method, uri, null, null, null, null,
-                null, Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap(), null
+                null, Collections.<String, String>emptyMap(), Collections.<String, String[]>emptyMap(), null
         );
     }
 
@@ -98,7 +99,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
                                String method, String scheme, String host, Integer port, String path) {
         this(
                 requestHandler, respondTo, orchestration, method, null, scheme, host, port, path,
-                null, Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap(), null
+                null, Collections.<String, String>emptyMap(), Collections.<String, String[]>emptyMap(), null
         );
     }
 
@@ -185,7 +186,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
         return headers;
     }
 
-    public Map<String, String> getParams() {
+    public Map<String, String[]> getParams() {
         return params;
     }
 }

--- a/src/main/java/org/openhim/mediator/engine/messages/MediatorHTTPRequest.java
+++ b/src/main/java/org/openhim/mediator/engine/messages/MediatorHTTPRequest.java
@@ -7,9 +7,10 @@
 package org.openhim.mediator.engine.messages;
 
 import akka.actor.ActorRef;
+import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -23,11 +24,11 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
     private final String path;
     private final String body;
     private final Map<String, String> headers;
-    private final Map<String, String[]> params;
+    private final List<Pair<String, String>> params;
 
     private MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
                                String method, String uri, String scheme, String host, Integer port, String path, String body,
-                               Map<String, String> headers, Map<String, String[]> params, String correlationId) {
+                               Map<String, String> headers, List<Pair<String, String>> params, String correlationId) {
         super(requestHandler, respondTo, orchestration, correlationId);
         this.method = method;
         this.uri = uri;
@@ -44,7 +45,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
      * Construct a new mediator http request using a URI (string)
      */
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
-                               String method, String uri, String body, Map<String, String> headers, Map<String, String[]> params, String correlationId) {
+                               String method, String uri, String body, Map<String, String> headers, List<Pair<String, String>> params, String correlationId) {
         this(
                 requestHandler, respondTo, orchestration, method, uri, null, null, null, null, body, headers, params, correlationId
         );
@@ -55,7 +56,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
      */
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
                                String method, String scheme, String host, Integer port, String path, String body,
-                               Map<String, String> headers, Map<String, String[]> params, String correlationId) {
+                               Map<String, String> headers, List<Pair<String, String>> params, String correlationId) {
         this(
                 requestHandler, respondTo, orchestration, method, null, scheme, host, port, path, body, headers, params, correlationId
         );
@@ -65,7 +66,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
      * Construct a new mediator http request using a URI (string)
      */
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
-                               String method, String uri, String body, Map<String, String> headers, Map<String, String[]> params) {
+                               String method, String uri, String body, Map<String, String> headers, List<Pair<String, String>> params) {
         this(
                 requestHandler, respondTo, orchestration, method, uri, null, null, null, null, body, headers, params, null
         );
@@ -76,7 +77,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
      */
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration,
                                String method, String scheme, String host, Integer port, String path, String body,
-                               Map<String, String> headers, Map<String, String[]> params) {
+                               Map<String, String> headers, List<Pair<String, String>> params) {
         this(
                 requestHandler, respondTo, orchestration, method, null, scheme, host, port, path, body, headers, params, null
         );
@@ -88,7 +89,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
     public MediatorHTTPRequest(ActorRef requestHandler, ActorRef respondTo, String orchestration, String method, String uri) {
         this(
                 requestHandler, respondTo, orchestration, method, uri, null, null, null, null,
-                null, Collections.<String, String>emptyMap(), Collections.<String, String[]>emptyMap(), null
+                null, Collections.<String, String>emptyMap(), Collections.<Pair<String, String>>emptyList(), null
         );
     }
 
@@ -99,7 +100,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
                                String method, String scheme, String host, Integer port, String path) {
         this(
                 requestHandler, respondTo, orchestration, method, null, scheme, host, port, path,
-                null, Collections.<String, String>emptyMap(), Collections.<String, String[]>emptyMap(), null
+                null, Collections.<String, String>emptyMap(), Collections.<Pair<String, String>>emptyList(), null
         );
     }
 
@@ -119,7 +120,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
                 requestToCopy.getPath(),
                 requestToCopy.getBody(),
                 copyOfHeaders(requestToCopy.getHeaders()),
-                requestToCopy.getParams()!=null ? new HashMap<>(requestToCopy.getParams()) : null,
+                requestToCopy.getParams()!=null ? new ArrayList<>(requestToCopy.getParams()) : null,
                 requestToCopy.getCorrelationId()
         );
     }
@@ -140,7 +141,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
                 requestToCopy.getPath(),
                 requestToCopy.getBody(),
                 copyOfHeaders(requestToCopy.getHeaders()),
-                requestToCopy.getParams()!=null ? new HashMap<>(requestToCopy.getParams()) : null,
+                requestToCopy.getParams()!=null ? new ArrayList<>(requestToCopy.getParams()) : null,
                 correlationId
         );
     }
@@ -186,7 +187,7 @@ public class MediatorHTTPRequest extends MediatorRequestMessage {
         return headers;
     }
 
-    public Map<String, String[]> getParams() {
+    public List<Pair<String,String>> getParams() {
         return params;
     }
 }


### PR DESCRIPTION
@rcrichton if you've got space, would you mind taking a look at this?

The engine neglected to handle multiple query params that have the same name, because it was using a String -> String map. I've changed it to use a List<Pair> now.