### PR TITLE
Enables default UTF-8 http transfer encoding.

### DIFF
--- a/src/main/java/org/openhim/mediator/engine/MediatorConfig.java
+++ b/src/main/java/org/openhim/mediator/engine/MediatorConfig.java
@@ -139,6 +139,8 @@ public class MediatorConfig {
 
     private SSLContext sslContext;
 
+    private String transferEncoding = "UTF-8";
+
     private boolean heartbeatsEnabled = false;
     private int heartbeatPeriodSeconds = 10;
 
@@ -449,5 +451,19 @@ public class MediatorConfig {
      */
     public void setSSLContext(SSLContext sslContext) {
         this.sslContext = sslContext;
+    }
+
+    /**
+     * @see #setTransferEncoding(String)
+     */
+    public String getTransferEncoding() {
+        return transferEncoding;
+    }
+
+    /**
+     * The HTTP transfer encoding to use for requests. Defaults to "UTF-8" if not set.
+     */
+    public void setTransferEncoding(String transferEncoding) {
+        this.transferEncoding = transferEncoding;
     }
 }

--- a/src/main/java/org/openhim/mediator/engine/MediatorRootActor.java
+++ b/src/main/java/org/openhim/mediator/engine/MediatorRootActor.java
@@ -78,7 +78,7 @@ public class MediatorRootActor extends UntypedActor {
             }
         }
 
-        getContext().actorOf(Props.create(HTTPConnector.class), "http-connector");
+        getContext().actorOf(Props.create(HTTPConnector.class, config), "http-connector");
         getContext().actorOf(Props.create(CoreAPIConnector.class, config), "core-api-connector");
         getContext().actorOf(Props.create(MLLPConnector.class), "mllp-connector");
         getContext().actorOf(Props.create(UDPFireForgetConnector.class), "udp-fire-forget-connector");

--- a/src/main/java/org/openhim/mediator/engine/MediatorServer.java
+++ b/src/main/java/org/openhim/mediator/engine/MediatorServer.java
@@ -103,6 +103,9 @@ public class MediatorServer {
         httpServer.getServerConfiguration().addHttpHandler(new HttpHandler() {
             @Override
             public void service(Request request, Response response) throws Exception {
+                request.setCharacterEncoding(config.getTransferEncoding());
+                response.setCharacterEncoding(config.getTransferEncoding());
+                
                 response.suspend();
                 rootActor.tell(new GrizzlyHTTPRequest(request, response), ActorRef.noSender());
             }

--- a/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
+++ b/src/main/java/org/openhim/mediator/engine/connectors/HTTPConnector.java
@@ -55,8 +55,19 @@ public class HTTPConnector extends UntypedActor {
 
     LoggingAdapter log = Logging.getLogger(getContext().system(), this);
 
+    private final MediatorConfig config;
+
     private SSLContext sslContext;
     private boolean sslTrustAll;
+
+
+    public HTTPConnector() {
+        this(new MediatorConfig());
+    }
+
+    public HTTPConnector(MediatorConfig config) {
+        this.config = config;
+    }
 
 
     private void copyHeaders(MediatorHTTPRequest src, HttpUriRequest dst) {
@@ -100,12 +111,12 @@ public class HTTPConnector extends UntypedActor {
                 break;
             case "POST":
                 uriReq = new HttpPost(buildURI(req));
-                StringEntity entity = new StringEntity(req.getBody());
+                StringEntity entity = new StringEntity(req.getBody(), config.getTransferEncoding());
                 ((HttpPost) uriReq).setEntity(entity);
                 break;
             case "PUT":
                 uriReq = new HttpPut(buildURI(req));
-                StringEntity putEntity = new StringEntity(req.getBody());
+                StringEntity putEntity = new StringEntity(req.getBody(), config.getTransferEncoding());
                 ((HttpPut) uriReq).setEntity(putEntity);
                 break;
             case "DELETE":

--- a/src/test/java/org/openhim/mediator/engine/connectors/HTTPConnectorTest.java
+++ b/src/test/java/org/openhim/mediator/engine/connectors/HTTPConnectorTest.java
@@ -265,6 +265,57 @@ public class HTTPConnectorTest {
     }
 
     @Test
+    public void testGETRequestWithGermanUmlauts() throws Exception {
+        wireMockRule.stubFor(get(urlEqualTo("/test/get/umlauts"))
+                        .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "text/plain; charset=UTF-8").withBody("Liebe Grüße aus Österreich: äöüÄÖÜß"))
+        );
+
+        new HTTPConnectorTestKit(system) {{
+            testHTTPMessage(new MediatorHTTPRequest(
+                    getRef(),
+                    getRef(),
+                    "unit-test",
+                    "GET",
+                    "http",
+                    "localhost",
+                    wireMockRule.port(),
+                    "/test/get/umlauts"
+            ), 200, "text/plain; charset=UTF-8", "Liebe Grüße aus Österreich: äöüÄÖÜß");
+
+            wireMockRule.verify(getRequestedFor(urlEqualTo("/test/get/umlauts")));
+        }};
+    }
+
+    @Test
+    public void testPOSTRequestWithGermanUmlauts() throws Exception {
+        wireMockRule.stubFor(post(urlEqualTo("/test/post/umlauts"))
+                        .willReturn(aResponse().withStatus(201).withHeader("Content-Type", "text/plain; charset=UTF-8").withBody("Created"))
+        );
+
+        new HTTPConnectorTestKit(system) {{
+            testHTTPMessage(new MediatorHTTPRequest(
+                    getRef(),
+                    getRef(),
+                    "unit-test",
+                    "POST",
+                    "http",
+                    "localhost",
+                    wireMockRule.port(),
+                    "/test/post/umlauts",
+                    "<message>Liebe Grüße aus Österreich: äöüÄÖÜß</message>",
+                    Collections.singletonMap("Content-Type", "text/xml; charset=UTF-8"),
+                    null
+            ), 201, "text/plain; charset=UTF-8", "Created");
+
+            wireMockRule.verify(
+                    postRequestedFor(urlEqualTo("/test/post/umlauts"))
+                    .withHeader("Content-Type", equalTo("text/xml; charset=UTF-8"))
+                    .withRequestBody(equalTo("<message>Liebe Grüße aus Österreich: äöüÄÖÜß</message>"))
+            );
+        }};
+    }
+
+    @Test
     public void testGETRequestWithURI() throws Exception {
         wireMockRule.stubFor(get(urlEqualTo("/test/get/with/uri"))
                 .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "text/plain").withBody("test"))


### PR DESCRIPTION
GlassFish HttpServletRequest.getCharacterEncoding() falls back to ISO-8859-1.

Often UTF-8 encoding is required.

The following updates provide an option to set the encoding for the HTTP functionality and sets default UTF-8 because it is currently more widely used.